### PR TITLE
Make safetensors properly optional, and support storing TI

### DIFF
--- a/lora_diffusion/cli_pt_to_safetensors.py
+++ b/lora_diffusion/cli_pt_to_safetensors.py
@@ -1,0 +1,85 @@
+import os
+
+import fire
+import torch
+from lora_diffusion import (
+    DEFAULT_TARGET_REPLACE,
+    TEXT_ENCODER_DEFAULT_TARGET_REPLACE,
+    UNET_DEFAULT_TARGET_REPLACE,
+    convert_loras_to_safeloras_with_embeds,
+    safetensors_available,
+)
+
+_target_by_name = {
+    "unet": UNET_DEFAULT_TARGET_REPLACE,
+    "text_encoder": TEXT_ENCODER_DEFAULT_TARGET_REPLACE,
+}
+
+
+def convert(*paths, outpath, overwrite=False, **settings):
+    """
+    Converts one or more pytorch Lora and/or Textual Embedding pytorch files
+    into a safetensor file.
+
+    Pass all the input paths as arguments. Whether they are Textual Embedding
+    or Lora models will be auto-detected.
+
+    For Lora models, their name will be taken from the path, i.e.
+        "lora_weight.pt" => unet
+        "lora_weight.text_encoder.pt" => text_encoder
+
+    You can also set target_modules and/or rank by providing an argument prefixed
+    by the name.
+
+    So a complete example might be something like:
+
+    ```
+    python -m lora_diffusion.cli_pt_to_safetensors lora_weight.* --outpath lora_weight.safetensor --unet.rank 8
+    ```
+    """
+    modelmap = {}
+    embeds = {}
+
+    if os.path.exists(outpath) and not overwrite:
+        raise ValueError(
+            f"Output path {outpath} already exists, and overwrite is not True"
+        )
+
+    for path in paths:
+        data = torch.load(path)
+
+        if isinstance(data, dict):
+            print(f"Loading textual inversion embeds {data.keys()} from {path}")
+            embeds.update(data)
+
+        else:
+            name_parts = os.path.split(path)[1].split(".")
+            name = name_parts[-2] if len(name_parts) > 2 else "unet"
+
+            model_settings = {
+                "target_modules": _target_by_name.get(name, DEFAULT_TARGET_REPLACE),
+                "rank": 4,
+            }
+
+            prefix = f"{name}."
+            model_settings |= {
+                k[len(prefix) :]: v for k, v in settings.items() if k.startswith(prefix)
+            }
+
+            print(f"Loading Lora for {name} from {path} with settings {model_settings}")
+
+            modelmap[name] = (
+                path,
+                model_settings["target_modules"],
+                model_settings["rank"],
+            )
+
+    convert_loras_to_safeloras_with_embeds(modelmap, embeds, outpath)
+
+
+def main():
+    fire.Fire(convert)
+
+
+if __name__ == "__main__":
+    main()

--- a/lora_diffusion/safe_open.py
+++ b/lora_diffusion/safe_open.py
@@ -1,0 +1,68 @@
+"""
+Pure python version of Safetensors safe_open
+From https://gist.github.com/Narsil/3edeec2669a5e94e4707aa0f901d2282
+"""
+
+import json
+import mmap
+import os
+
+import torch
+
+
+class SafetensorsWrapper:
+    def __init__(self, metadata, tensors):
+        self._metadata = metadata
+        self._tensors = tensors
+
+    def metadata(self):
+        return self._metadata
+
+    def keys(self):
+        return self._tensors.keys()
+
+    def get_tensor(self, k):
+        return self._tensors[k]
+
+
+DTYPES = {
+    "F32": torch.float32,
+    "F16": torch.float16,
+    "BF16": torch.bfloat16,
+}
+
+
+def create_tensor(storage, info, offset):
+    dtype = DTYPES[info["dtype"]]
+    shape = info["shape"]
+    start, stop = info["data_offsets"]
+    return (
+        torch.asarray(storage[start + offset : stop + offset], dtype=torch.uint8)
+        .view(dtype=dtype)
+        .reshape(shape)
+    )
+
+
+def safe_open(filename, framework="pt", device="cpu"):
+    if framework != "pt":
+        raise ValueError("`framework` must be 'pt'")
+
+    with open(filename, mode="r", encoding="utf8") as file_obj:
+        with mmap.mmap(file_obj.fileno(), length=0, access=mmap.ACCESS_READ) as m:
+            header = m.read(8)
+            n = int.from_bytes(header, "little")
+            metadata_bytes = m.read(n)
+            metadata = json.loads(metadata_bytes)
+
+    size = os.stat(filename).st_size
+    storage = torch.ByteStorage.from_file(filename, shared=False, size=size).untyped()
+    offset = n + 8
+
+    return SafetensorsWrapper(
+        metadata=metadata.get("__metadata__", {}),
+        tensors={
+            name: create_tensor(storage, info, offset).to(device)
+            for name, info in metadata.items()
+            if name != "__metadata__"
+        },
+    )

--- a/train_lora_dreambooth.py
+++ b/train_lora_dreambooth.py
@@ -33,6 +33,7 @@ from transformers import CLIPTextModel, CLIPTokenizer
 from lora_diffusion import (
     extract_lora_ups_down,
     inject_trainable_lora,
+    safetensors_available,
     save_lora_weight,
     save_safeloras,
 )
@@ -264,6 +265,13 @@ def parse_args(input_args=None):
         help="The output directory where the model predictions and checkpoints will be written.",
     )
     parser.add_argument(
+        "--output_format",
+        type=str,
+        choices=["pt", "safe", "both"],
+        default="both",
+        help="The output format of the model predicitions and checkpoints.",
+    )
+    parser.add_argument(
         "--seed", type=int, default=None, help="A seed for reproducible training."
     )
     parser.add_argument(
@@ -473,6 +481,17 @@ def parse_args(input_args=None):
         if args.class_prompt is not None:
             logger.warning(
                 "You need not use --class_prompt without --with_prior_preservation."
+            )
+
+    if not safetensors_available:
+        if args.output_format == "both":
+            print(
+                "Safetensors is not available - changing output format to just output PyTorch files"
+            )
+            args.output_format = "pt"
+        elif args.output_format == "safe":
+            raise ValueError(
+                "Safetensors is not available - either install it, or change output_format."
             )
 
     return args
@@ -967,26 +986,29 @@ def main(args):
 
         print("\n\nLora TRAINING DONE!\n\n")
 
-        save_lora_weight(pipeline.unet, args.output_dir + "/lora_weight.pt")
-        if args.train_text_encoder:
-            save_lora_weight(
-                pipeline.text_encoder,
-                args.output_dir + "/lora_weight.text_encoder.pt",
-                target_replace_module=["CLIPAttention"],
-            )
+        if args.output_format == "pt" or args.output_format == "both":
+            save_lora_weight(pipeline.unet, args.output_dir + "/lora_weight.pt")
+            if args.train_text_encoder:
+                save_lora_weight(
+                    pipeline.text_encoder,
+                    args.output_dir + "/lora_weight.text_encoder.pt",
+                    target_replace_module=["CLIPAttention"],
+                )
+
+        if args.output_format == "safe" or args.output_format == "both":
+            loras = {}
+            loras["unet"] = (pipeline.unet, {"CrossAttention", "Attention", "GEGLU"})
+            if args.train_text_encoder:
+                loras["text_encoder"] = (pipeline.text_encoder, {"CLIPAttention"})
+
+            save_safeloras(loras, args.output_dir + "/lora_weight.safetensors")
 
         if args.push_to_hub:
             repo.push_to_hub(
-                commit_message="End of training", blocking=False, auto_lfs_prune=True
+                commit_message="End of training",
+                blocking=False,
+                auto_lfs_prune=True,
             )
-
-        save_safeloras(
-            {
-                "unet": (pipeline.unet, {"CrossAttention", "Attention", "GEGLU"}),
-                "text_encoder": (pipeline.text_encoder, {"CLIPAttention"}),
-            },
-            args.output_dir + "/lora_weight.safetensors",
-        )
 
     accelerator.end_training()
 

--- a/train_lora_w_ti.py
+++ b/train_lora_w_ti.py
@@ -32,9 +32,11 @@ from tqdm.auto import tqdm
 from transformers import CLIPTextModel, CLIPTokenizer
 
 from lora_diffusion import (
-    inject_trainable_lora,
-    save_lora_weight,
     extract_lora_ups_down,
+    inject_trainable_lora,
+    safetensors_available,
+    save_lora_weight,
+    save_safeloras_with_embeds,
 )
 
 from torch.utils.data import Dataset
@@ -370,6 +372,13 @@ def parse_args(input_args=None):
         help="The output directory where the model predictions and checkpoints will be written.",
     )
     parser.add_argument(
+        "--output_format",
+        type=str,
+        choices=["pt", "safe", "both"],
+        default="both",
+        help="The output format of the model predicitions and checkpoints.",
+    )
+    parser.add_argument(
         "--seed", type=int, default=None, help="A seed for reproducible training."
     )
     parser.add_argument(
@@ -598,6 +607,17 @@ def parse_args(input_args=None):
         if args.class_prompt is not None:
             logger.warning(
                 "You need not use --class_prompt without --with_prior_preservation."
+            )
+
+    if not safetensors_available:
+        if args.output_format == "both":
+            print(
+                "Safetensors is not available - changing output format to just output PyTorch files"
+            )
+            args.output_format = "pt"
+        elif args.output_format == "safe":
+            raise ValueError(
+                "Safetensors is not available - either install it, or change output_format."
             )
 
     return args
@@ -1148,13 +1168,31 @@ def main(args):
 
         print("\n\nLora TRAINING DONE!\n\n")
 
-        save_lora_weight(pipeline.unet, args.output_dir + "/lora_weight.pt")
+        if args.output_format == "pt" or args.output_format == "both":
+            save_lora_weight(pipeline.unet, args.output_dir + "/lora_weight.pt")
 
-        save_lora_weight(
-            text_encoder,
-            args.output_dir + "/lora_weight.text_encoder.pt",
-            target_replace_module=["CLIPAttention"],
-        )
+            save_lora_weight(
+                text_encoder,
+                args.output_dir + "/lora_weight.text_encoder.pt",
+                target_replace_module=["CLIPAttention"],
+            )
+
+        if args.output_format == "safe" or args.output_format == "both":
+            loras = {}
+            loras["unet"] = (pipeline.unet, {"CrossAttention", "Attention", "GEGLU"})
+            loras["text_encoder"] = (pipeline.text_encoder, {"CLIPAttention"})
+
+            learned_embeds = (
+                accelerator.unwrap_model(text_encoder)
+                .get_input_embeddings()
+                .weight[placeholder_token_id]
+            )
+
+            embeds = {args.placeholder_token: learned_embeds.detach().cpu()}
+
+            save_safeloras_with_embeds(
+                loras, embeds, args.output_dir + "/lora_weight.safetensors"
+            )
 
     accelerator.end_training()
 


### PR DESCRIPTION
Not fully tested yet, just raising to start reviewing. 

Should be fully backwards compatible on API, and make safetensors a properly optional dependancy (loading should work with the pure python version, saving requires the module but the default training script behaviour is to skip and only write pytorch models if it's not available)