### PR TITLE
[WIP] Add nonlinearity between Down and Up weights, expose alpha hyperparameter

### DIFF
--- a/lora_diffusion/cli_lora_add.py
+++ b/lora_diffusion/cli_lora_add.py
@@ -75,13 +75,13 @@ def add(
             path_1,
         ).to("cpu")
 
-        weight_apply_lora(loaded_pipeline.unet, torch.load(path_2), alpha=alpha)
+        weight_apply_lora(loaded_pipeline.unet, torch.load(path_2), scale=alpha)
         if with_text_lora:
 
             weight_apply_lora(
                 loaded_pipeline.text_encoder,
                 torch.load(_text_lora_path(path_2)),
-                alpha=alpha,
+                scale=alpha,
                 target_replace_module=["CLIPAttention"],
             )
 
@@ -93,12 +93,12 @@ def add(
             path_1,
         ).to("cpu")
 
-        weight_apply_lora(loaded_pipeline.unet, torch.load(path_2), alpha=alpha)
+        weight_apply_lora(loaded_pipeline.unet, torch.load(path_2), scale=alpha)
         if with_text_lora:
             weight_apply_lora(
                 loaded_pipeline.text_encoder,
                 torch.load(_text_lora_path(path_2)),
-                alpha=alpha,
+                scale=alpha,
                 target_replace_module=["CLIPAttention"],
             )
 

--- a/lora_diffusion/lora.py
+++ b/lora_diffusion/lora.py
@@ -23,7 +23,8 @@ class LoraInjectedLinear(nn.Module):
         self.lora_up = nn.Linear(r, out_features, bias=False)
         self.scale = 8.0
 
-        nn.init.normal_(self.lora_down.weight, std=1 / r)
+        #nn.init.normal_(self.lora_down.weight, std=1 / r)
+        nn.init.kaiming_uniform_(self.lora_down.weight, a=math.sqrt(5))
         nn.init.zeros_(self.lora_up.weight)
 
     def forward(self, input):

--- a/lora_diffusion/lora.py
+++ b/lora_diffusion/lora.py
@@ -21,10 +21,9 @@ class LoraInjectedLinear(nn.Module):
         self.linear = nn.Linear(in_features, out_features, bias)
         self.lora_down = nn.Linear(in_features, r, bias=False)
         self.lora_up = nn.Linear(r, out_features, bias=False)
-        self.scale = 32.0
+        self.scale = 1.0
 
-        #nn.init.normal_(self.lora_down.weight, std=1 / r)
-        nn.init.kaiming_uniform_(self.lora_down.weight, a=math.sqrt(5))
+        nn.init.normal_(self.lora_down.weight, std=1 / r)
         nn.init.zeros_(self.lora_up.weight)
 
     def forward(self, input):

--- a/lora_diffusion/lora.py
+++ b/lora_diffusion/lora.py
@@ -21,7 +21,7 @@ class LoraInjectedLinear(nn.Module):
         self.linear = nn.Linear(in_features, out_features, bias)
         self.lora_down = nn.Linear(in_features, r, bias=False)
         self.lora_up = nn.Linear(r, out_features, bias=False)
-        self.scale = 1.0
+        self.scale = 8.0
 
         nn.init.normal_(self.lora_down.weight, std=1 / r)
         nn.init.zeros_(self.lora_up.weight)

--- a/lora_diffusion/lora.py
+++ b/lora_diffusion/lora.py
@@ -32,7 +32,7 @@ class LoraInjectedLinear(nn.Module):
         self.scale = self.alpha / self.r
 
         if init=="kaiming":
-            nn.init.kaiming_uniform_(self.lora_down)
+            nn.init.kaiming_uniform_(self.lora_down, a=math.sqrt(5))
         else:
             nn.init.normal_(self.lora_down.weight, std=1 / r)
             

--- a/lora_diffusion/lora.py
+++ b/lora_diffusion/lora.py
@@ -27,7 +27,7 @@ class LoraInjectedLinear(nn.Module):
         self.alpha = alpha
         self.linear = nn.Linear(in_features, out_features, bias)
         self.lora_down = nn.Linear(in_features, r, bias=False)
-        self.nonlin = nonlin if nonlin is not None
+        self.nonlin = nonlin if nonlin else None
         self.lora_up = nn.Linear(r, out_features, bias=False)
         self.scale = self.alpha / self.r
 
@@ -39,7 +39,7 @@ class LoraInjectedLinear(nn.Module):
         nn.init.zeros_(self.lora_up.weight)
 
     def forward(self, input):
-        if self.nonlin is not None:
+        if self.nonlin:
             return self.linear(input) + self.lora_up(self.nonlin(self.lora_down(input))) * self.scale
         else:
             return self.linear(input) + self.lora_up(self.lora_down(input)) * self.scale

--- a/lora_diffusion/lora.py
+++ b/lora_diffusion/lora.py
@@ -21,7 +21,7 @@ class LoraInjectedLinear(nn.Module):
         self.linear = nn.Linear(in_features, out_features, bias)
         self.lora_down = nn.Linear(in_features, r, bias=False)
         self.lora_up = nn.Linear(r, out_features, bias=False)
-        self.scale = 8.0
+        self.scale = 32.0
 
         #nn.init.normal_(self.lora_down.weight, std=1 / r)
         nn.init.kaiming_uniform_(self.lora_down.weight, a=math.sqrt(5))

--- a/lora_diffusion/lora.py
+++ b/lora_diffusion/lora.py
@@ -132,6 +132,8 @@ def inject_trainable_lora(
     target_replace_module: Set[str] = DEFAULT_TARGET_REPLACE,
     r: int = 4,
     alpha: float = 4.0,
+    init=None,
+    nonlin=None,
     loras=None,  # path to lora .pt
 ):
     """
@@ -155,6 +157,8 @@ def inject_trainable_lora(
             _child_module.bias is not None,
             r=r,
             alpha=alpha,
+            init=init,
+            nonlin=nonlin,
         )
         _tmp.linear.weight = weight
         if bias is not None:
@@ -367,7 +371,12 @@ def weight_apply_lora(
 
 
 def monkeypatch_lora(
-    model, loras, target_replace_module=DEFAULT_TARGET_REPLACE, r: int = 4, alpha: float = 4.0,
+    model,
+    loras,
+    target_replace_module=DEFAULT_TARGET_REPLACE,
+    r: int = 4,
+    alpha: float = 4.0,
+    nonlin: nn.Module = None,
 ):
     for _module, name, _child_module in _find_modules(
         model, target_replace_module, search_class=[nn.Linear]
@@ -380,6 +389,7 @@ def monkeypatch_lora(
             _child_module.bias is not None,
             r=r,
             alpha=alpha,
+            nonline=nonlin,
         )
         _tmp.linear.weight = weight
 
@@ -403,7 +413,12 @@ def monkeypatch_lora(
 
 
 def monkeypatch_replace_lora(
-    model, loras, target_replace_module=DEFAULT_TARGET_REPLACE, r: int = 4, alpha: float = 4.0,
+    model,
+    loras,
+    target_replace_module=DEFAULT_TARGET_REPLACE,
+    r: int = 4,
+    alpha: float = 4.0,
+    nonlin: nn.Module = None,
 ):
     for _module, name, _child_module in _find_modules(
         model, target_replace_module, search_class=[LoraInjectedLinear]
@@ -416,7 +431,8 @@ def monkeypatch_replace_lora(
             _child_module.linear.bias is not None,
             r=r,
             alpha=alpha,
-        )
+            nonlin=nonlin,
+       )
         _tmp.linear.weight = weight
 
         if bias is not None:
@@ -444,6 +460,7 @@ def monkeypatch_or_replace_lora(
     target_replace_module=DEFAULT_TARGET_REPLACE,
     r: Union[int, List[int]] = 4,
     alpha: Union[float, List[float]] = 4.0,
+    nonlin: Union[float, List[nn.Module]] = None,
 ):
     for _module, name, _child_module in _find_modules(
         model, target_replace_module, search_class=[nn.Linear, LoraInjectedLinear]
@@ -462,6 +479,7 @@ def monkeypatch_or_replace_lora(
             _source.bias is not None,
             r=r.pop(0) if isinstance(r, list) else r,
             alpha=alpha.pop(0) if isinstance(alpha, list) else alpha,
+            nonlin=nonlin.pop(0) if isinstance(nonlin, list) else nonlin,
         )
         _tmp.linear.weight = weight
 


### PR DESCRIPTION
Not strictly a LoRA change, but quite easy to fit into the current code. The idea is that squeezing an element-wise nonlinearity in between the Down and Up transformations can in some cases increase your performance at essentially no cost.

I also exposed the alpha parameter (keeping the convention from the original LoRA paper that scale=alpha/rank), which can also get you some extra performance for little effort.

Ideas from this fantastic paper:

He, Junxian, et al. "Towards a unified view of parameter-efficient transfer learning." arXiv preprint arXiv:2110.04366 (2021).
https://arxiv.org/pdf/2110.04366.pdf

Any thoughts before I start testing more thoroughly?