### PR TITLE
Attempted fix: --resume_text_encoder in train_lora_dreambooth.py

### DIFF
--- a/train_lora_dreambooth.py
+++ b/train_lora_dreambooth.py
@@ -627,6 +627,7 @@ def main(args):
             text_encoder,
             target_replace_module=["CLIPAttention"],
             r=args.lora_rank,
+            loras=args.resume_text_encoder,
         )
         for _up, _down in extract_lora_ups_down(
             text_encoder, target_replace_module=["CLIPAttention"]


### PR DESCRIPTION
This attempted fix results in the following error. Putting it here in case someone can see the problem with inject_trainable_lora. Any help appreciated, thanks!

Traceback (most recent call last):
  File "C:\Users\<user>\lora\train_lora_dreambooth.py", line 1044, in <module>
    main(args)
  File "C:\Users\<user>\lora\train_lora_dreambooth.py", line 631, in main
    unet_lora_params, _ = inject_trainable_lora(
  File "C:\Users\<user>\lora\lora_diffusion\lora.py", line 176, in inject_trainable_lora
    _module._modules[name].lora_up.weight = loras.pop(0)
  File "F:\ANACONDA\envs\sd\lib\site-packages\torch\nn\modules\module.py", line 1228, in __setattr__
    raise TypeError("cannot assign '{}' as parameter '{}' "
TypeError: cannot assign 'torch.HalfTensor' as parameter 'weight' (torch.nn.Parameter or None expected)