### PR TITLE
Feature/ Better LoRA : Dropout, Conv2d

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,5 @@ __pycache__
 __test*
 merged_lora*
 wandb
-exps
+exps*
 .vscode

--- a/lora_diffusion/cli_lora_pti.py
+++ b/lora_diffusion/cli_lora_pti.py
@@ -532,7 +532,7 @@ def train(
     learning_rate_unet: float = 1e-4,
     learning_rate_text: float = 1e-5,
     learning_rate_ti: float = 5e-4,
-    continue_inversion: bool = True,
+    continue_inversion: bool = False,
     continue_inversion_lr: Optional[float] = None,
     use_face_segmentation_condition: bool = False,
     scale_lr: bool = False,
@@ -739,7 +739,8 @@ def train(
         )
         for param in params_to_freeze:
             param.requires_grad = False
-
+    else:
+        text_encoder.requires_grad_(False)
     if train_text_encoder:
         text_encoder_lora_params, _ = inject_trainable_lora(
             text_encoder,

--- a/lora_diffusion/lora.py
+++ b/lora_diffusion/lora.py
@@ -50,8 +50,71 @@ class LoraInjectedLinear(nn.Module):
         return self.linear(input) + self.lora_up(self.lora_down(input)) * self.scale
 
 
+class LoraInjectedConv2d(nn.Module):
+    def __init__(
+        self,
+        in_channels: int,
+        out_channels: int,
+        kernel_size,
+        stride=1,
+        padding=0,
+        dilation=1,
+        groups: int = 1,
+        bias: bool = True,
+        padding_mode: str = "zeros",
+        r: int = 4,
+    ):
+        super().__init__()
+        if r > min(in_channels, out_channels):
+            raise ValueError(
+                f"LoRA rank {r} must be less or equal than {min(in_channels, out_channels)}"
+            )
+
+        self.conv = nn.Conv2d(
+            in_channels=in_channels,
+            out_channels=out_channels,
+            kernel_size=kernel_size,
+            stride=stride,
+            padding=padding,
+            dilation=dilation,
+            groups=groups,
+            bias=bias,
+        )
+
+        self.lora_down = nn.Conv2d(
+            in_channels=in_channels,
+            out_channels=r,
+            kernel_size=kernel_size,
+            stride=stride,
+            padding=padding,
+            dilation=dilation,
+            groups=groups,
+            bias=False,
+        )
+        self.lora_up = nn.Conv2d(
+            in_channels=r,
+            out_channels=out_channels,
+            kernel_size=1,
+            stride=1,
+            padding=0,
+            bias=False,
+        )
+        self.scale = 1.0
+
+        nn.init.normal_(self.lora_down.weight, std=1 / r)
+        nn.init.zeros_(self.lora_up.weight)
+
+    def forward(self, input):
+        return self.conv(input) + self.lora_up(self.lora_down(input)) * self.scale
+
+
 UNET_DEFAULT_TARGET_REPLACE = {"CrossAttention", "Attention", "GEGLU"}
+
+UNET_EXTENDED_TARGET_REPLACE = {"ResnetBlock2D", "CrossAttention", "Attention", "GEGLU"}
+
 TEXT_ENCODER_DEFAULT_TARGET_REPLACE = {"CLIPAttention"}
+
+TEXT_ENCODER_EXTENDED_TARGET_REPLACE = {"CLIPAttention"}
 
 DEFAULT_TARGET_REPLACE = UNET_DEFAULT_TARGET_REPLACE
 
@@ -183,12 +246,85 @@ def inject_trainable_lora(
     return require_grad_params, names
 
 
+def inject_trainable_lora_extended(
+    model: nn.Module,
+    target_replace_module: Set[str] = UNET_EXTENDED_TARGET_REPLACE,
+    r: int = 4,
+    loras=None,  # path to lora .pt
+):
+    """
+    inject lora into model, and returns lora parameter groups.
+    """
+
+    require_grad_params = []
+    names = []
+
+    if loras != None:
+        loras = torch.load(loras)
+
+    for _module, name, _child_module in _find_modules(
+        model, target_replace_module, search_class=[nn.Linear, nn.Conv2d]
+    ):
+        if _child_module.__class__ == nn.Linear:
+            weight = _child_module.weight
+            bias = _child_module.bias
+            _tmp = LoraInjectedLinear(
+                _child_module.in_features,
+                _child_module.out_features,
+                _child_module.bias is not None,
+                r,
+            )
+            _tmp.linear.weight = weight
+            if bias is not None:
+                _tmp.linear.bias = bias
+        elif _child_module.__class__ == nn.Conv2d:
+            weight = _child_module.weight
+            bias = _child_module.bias
+            _tmp = LoraInjectedConv2d(
+                _child_module.in_channels,
+                _child_module.out_channels,
+                _child_module.kernel_size,
+                _child_module.stride,
+                _child_module.padding,
+                _child_module.dilation,
+                _child_module.groups,
+                _child_module.bias is not None,
+                r,
+            )
+
+            _tmp.conv.weight = weight
+            if bias is not None:
+                _tmp.conv.bias = bias
+
+        # switch the module
+        _tmp.to(_child_module.weight.device).to(_child_module.weight.dtype)
+        if bias is not None:
+            _tmp.to(_child_module.bias.device).to(_child_module.bias.dtype)
+
+        _module._modules[name] = _tmp
+
+        require_grad_params.append(_module._modules[name].lora_up.parameters())
+        require_grad_params.append(_module._modules[name].lora_down.parameters())
+
+        if loras != None:
+            _module._modules[name].lora_up.weight = loras.pop(0)
+            _module._modules[name].lora_down.weight = loras.pop(0)
+
+        _module._modules[name].lora_up.weight.requires_grad = True
+        _module._modules[name].lora_down.weight.requires_grad = True
+        names.append(name)
+
+    return require_grad_params, names
+
+
 def extract_lora_ups_down(model, target_replace_module=DEFAULT_TARGET_REPLACE):
 
     loras = []
 
     for _m, _n, _child_module in _find_modules(
-        model, target_replace_module, search_class=[LoraInjectedLinear]
+        model,
+        target_replace_module,
+        search_class=[LoraInjectedLinear, LoraInjectedConv2d],
     ):
         loras.append((_child_module.lora_up, _child_module.lora_down))
 
@@ -246,7 +382,12 @@ def save_safeloras_with_embeds(
         for i, (_up, _down) in enumerate(
             extract_lora_ups_down(model, target_replace_module)
         ):
-            metadata[f"{name}:{i}:rank"] = str(_down.out_features)
+            try:
+                rank = getattr(_down, "out_features")
+            except:
+                rank = getattr(_down, "out_channels")
+
+            metadata[f"{name}:{i}:rank"] = str(rank)
             weights[f"{name}:{i}:up"] = _up.weight
             weights[f"{name}:{i}:down"] = _down.weight
 
@@ -424,76 +565,6 @@ def weight_apply_lora(
         _child_module.weight = nn.Parameter(weight)
 
 
-def monkeypatch_lora(
-    model, loras, target_replace_module=DEFAULT_TARGET_REPLACE, r: int = 4
-):
-    for _module, name, _child_module in _find_modules(
-        model, target_replace_module, search_class=[nn.Linear]
-    ):
-        weight = _child_module.weight
-        bias = _child_module.bias
-        _tmp = LoraInjectedLinear(
-            _child_module.in_features,
-            _child_module.out_features,
-            _child_module.bias is not None,
-            r=r,
-        )
-        _tmp.linear.weight = weight
-
-        if bias is not None:
-            _tmp.linear.bias = bias
-
-        # switch the module
-        _module._modules[name] = _tmp
-
-        up_weight = loras.pop(0)
-        down_weight = loras.pop(0)
-
-        _module._modules[name].lora_up.weight = nn.Parameter(
-            up_weight.type(weight.dtype)
-        )
-        _module._modules[name].lora_down.weight = nn.Parameter(
-            down_weight.type(weight.dtype)
-        )
-
-        _module._modules[name].to(weight.device)
-
-
-def monkeypatch_replace_lora(
-    model, loras, target_replace_module=DEFAULT_TARGET_REPLACE, r: int = 4
-):
-    for _module, name, _child_module in _find_modules(
-        model, target_replace_module, search_class=[LoraInjectedLinear]
-    ):
-        weight = _child_module.linear.weight
-        bias = _child_module.linear.bias
-        _tmp = LoraInjectedLinear(
-            _child_module.linear.in_features,
-            _child_module.linear.out_features,
-            _child_module.linear.bias is not None,
-            r=r,
-        )
-        _tmp.linear.weight = weight
-
-        if bias is not None:
-            _tmp.linear.bias = bias
-
-        # switch the module
-        _module._modules[name] = _tmp
-
-        up_weight = loras.pop(0)
-        down_weight = loras.pop(0)
-
-        _module._modules[name].lora_up.weight = nn.Parameter(
-            up_weight.type(weight.dtype)
-        )
-        _module._modules[name].lora_down.weight = nn.Parameter(
-            down_weight.type(weight.dtype)
-        )
-
-        _module._modules[name].to(weight.device)
-
-
 def monkeypatch_or_replace_lora(
     model,
     loras,
@@ -538,6 +609,88 @@ def monkeypatch_or_replace_lora(
         _module._modules[name].to(weight.device)
 
 
+def monkeypatch_or_replace_lora_extended(
+    model,
+    loras,
+    target_replace_module=DEFAULT_TARGET_REPLACE,
+    r: Union[int, List[int]] = 4,
+):
+    for _module, name, _child_module in _find_modules(
+        model,
+        target_replace_module,
+        search_class=[nn.Linear, LoraInjectedLinear, nn.Conv2d, LoraInjectedConv2d],
+    ):
+
+        if (
+            _child_module.__class__ == nn.Linear
+            or _child_module.__class__ == LoraInjectedLinear
+        ):
+            if len(loras[0].shape) != 2:
+                continue
+
+            _source = (
+                _child_module.linear
+                if isinstance(_child_module, LoraInjectedLinear)
+                else _child_module
+            )
+
+            weight = _source.weight
+            bias = _source.bias
+            _tmp = LoraInjectedLinear(
+                _source.in_features,
+                _source.out_features,
+                _source.bias is not None,
+                r=r.pop(0) if isinstance(r, list) else r,
+            )
+            _tmp.linear.weight = weight
+
+            if bias is not None:
+                _tmp.linear.bias = bias
+
+        elif _child_module.__class__ == nn.Conv2d:
+            if len(loras[0].shape) != 4:
+                continue
+            _source = (
+                _child_module.conv
+                if isinstance(_child_module, LoraInjectedConv2d)
+                else _child_module
+            )
+
+            weight = _child_module.weight
+            bias = _child_module.bias
+            _tmp = LoraInjectedConv2d(
+                _child_module.in_channels,
+                _child_module.out_channels,
+                _child_module.kernel_size,
+                _child_module.stride,
+                _child_module.padding,
+                _child_module.dilation,
+                _child_module.groups,
+                _child_module.bias is not None,
+                r=r.pop(0) if isinstance(r, list) else r,
+            )
+
+            _tmp.conv.weight = weight
+
+            if bias is not None:
+                _tmp.conv.bias = bias
+
+        # switch the module
+        _module._modules[name] = _tmp
+
+        up_weight = loras.pop(0)
+        down_weight = loras.pop(0)
+
+        _module._modules[name].lora_up.weight = nn.Parameter(
+            up_weight.type(weight.dtype)
+        )
+        _module._modules[name].lora_down.weight = nn.Parameter(
+            down_weight.type(weight.dtype)
+        )
+
+        _module._modules[name].to(weight.device)
+
+
 def monkeypatch_or_replace_safeloras(models, safeloras):
     loras = parse_safeloras(safeloras)
 
@@ -548,7 +701,7 @@ def monkeypatch_or_replace_safeloras(models, safeloras):
             print(f"No model provided for {name}, contained in Lora")
             continue
 
-        monkeypatch_or_replace_lora(model, lora, target, ranks)
+        monkeypatch_or_replace_lora_extended(model, lora, target, ranks)
 
 
 def monkeypatch_remove_lora(model):
@@ -755,9 +908,9 @@ def inspect_lora(model):
 def save_all(
     unet,
     text_encoder,
-    placeholder_token_ids,
-    placeholder_tokens,
     save_path,
+    placeholder_token_ids=None,
+    placeholder_tokens=None,
     save_lora=True,
     save_ti=True,
     target_replace_module_text=TEXT_ENCODER_DEFAULT_TARGET_REPLACE,
@@ -801,7 +954,7 @@ def save_all(
         ), f"Save path : {save_path} should end with .safetensors"
 
         loras = {}
-        embeds = None
+        embeds = {}
 
         if save_lora:
 
@@ -809,7 +962,6 @@ def save_all(
             loras["text_encoder"] = (text_encoder, target_replace_module_text)
 
         if save_ti:
-            embeds = {}
             for tok, tok_id in zip(placeholder_tokens, placeholder_token_ids):
                 learned_embeds = text_encoder.get_input_embeddings().weight[tok_id]
                 print(

--- a/lora_diffusion/lora.py
+++ b/lora_diffusion/lora.py
@@ -749,7 +749,7 @@ def monkeypatch_add_lora(
 
 def tune_lora_scale(model, alpha: float = 1.0):
     for _module in model.modules():
-        if _module.__class__.__name__ == "LoraInjectedLinear":
+        if _module.__class__.__name__ in ["LoraInjectedLinear", "LoraInjectedConv2d"]:
             _module.scale = alpha
 
 

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import find_packages, setup
 setup(
     name="lora_diffusion",
     py_modules=["lora_diffusion"],
-    version="0.1.0",
+    version="0.1.2",
     description="Low Rank Adaptation for Diffusion Models. Works with Stable Diffusion out-of-the-box.",
     author="Simo Ryu",
     packages=find_packages(),


### PR DESCRIPTION
So unlike classical LLMs, LoRA also has other many modules as well. Arguably, it seems like many "important" features come from Resnet features. This is clearly demonstrated by, for example, plug-and-play prior

![image](https://user-images.githubusercontent.com/35953539/212417042-aaa54b29-4464-46da-8e3f-de35694b2271.png)
> Check out the details on this paper : https://pnp-diffusion.github.io/

Natural question to ask is : Does dreambooth yield fine-grained level of details, such as eyes or skins, because it is able to tune resnets? Is Q, K, V, O simply not enough?

In this PR I will try to answer this questions with bunch of experiments.

Here are some initial results : 

This result is LoRA rank 4, with "CrossAttention", "Attention", "GEGLU" Replaced

![pr_no](https://user-images.githubusercontent.com/35953539/212417978-10cae65f-51cf-456e-9c44-298c27a4a9d0.jpg)

Now, this is LoRA rank 1, with "ResnetBlock2D", "CrossAttention", "Attention", "GEGLU" Replaced. Now, number of parameters are now about as 2 times higher : as high as 9.7MB. Of which, only 2MB is LoRA of  "CrossAttention", "Attention", "GEGLU", so I suspect that if it helps, we might make LoRA of  TR rank 4 and LoRA of Resnet rank 1.

![pr_res](https://user-images.githubusercontent.com/35953539/212417986-1b6e1ab3-8892-42c7-b578-990a5379417f.jpg)

All trained with same number of steps, sampled with same parameters. This case, it looks like its a tie. I'll try on other models as well. I think it is a good time to start implementing fidelity metrics as well, instead of CLIP alignment score.