### PR TITLE
Avoid using python 3.9 feature ( |= for dict ) so cli_pt_to_safetenso…

### DIFF
--- a/lora_diffusion/cli_pt_to_safetensors.py
+++ b/lora_diffusion/cli_pt_to_safetensors.py
@@ -62,9 +62,9 @@ def convert(*paths, outpath, overwrite=False, **settings):
             }
 
             prefix = f"{name}."
-            model_settings |= {
-                k[len(prefix) :]: v for k, v in settings.items() if k.startswith(prefix)
-            }
+            
+            arg_settings = { k[len(prefix) :]: v for k, v in settings.items() if k.startswith(prefix) }
+            model_settings = { **model_settings, **arg_settings }
 
             print(f"Loading Lora for {name} from {path} with settings {model_settings}")
 


### PR DESCRIPTION
…r can be used in colab (python 3.8)