### PR TITLE
Include mediapipe package in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ wandb
 safetensors
 opencv-python
 torchvision
+mediapipe


### PR DESCRIPTION
Face segmentation uses mediapipe to generate the condition masks, but the requirements.txt didn't specify it. Adding so others don't run into the same error.