### PR TITLE
Update cli_lora_add.py

### DIFF
--- a/lora_diffusion/cli_lora_add.py
+++ b/lora_diffusion/cli_lora_add.py
@@ -105,6 +105,8 @@ def add(
                     ret_tensor[keys] = tens1
 
             save_file(ret_tensor, output_path, metadata)
+        else:
+             raise ValueError(f"{mode} chosen, but both paths have mismatches file extension.")
 
     elif mode == "upl":
 


### PR DESCRIPTION
Raise error for lora add case when both paths for default mode do not match.

I had a pretty big headache debugging this issue as I was onboarding diffusers into a ML pipeline