### PR TITLE
fixed: Accelerator init logging_dir->project_dir

### DIFF
--- a/training_scripts/train_lora_dreambooth.py
+++ b/training_scripts/train_lora_dreambooth.py
@@ -490,7 +490,7 @@ def main(args):
         gradient_accumulation_steps=args.gradient_accumulation_steps,
         mixed_precision=args.mixed_precision,
         log_with="tensorboard",
-        logging_dir=logging_dir,
+        project_dir=logging_dir,
     )
 
     # Currently, it's not possible to do gradient accumulation when training two models with accelerate.accumulate


### PR DESCRIPTION
when start [colab running example](https://colab.research.google.com/drive/1iSFDpRBKEWr2HLlz243rbym3J2X95kcy?usp=sharing)  i  get:  

`TypeError: Accelerator.__init__() got an unexpected keyword argument 'logging_dir'; `

Just replace `logging_dir` to `project_dir` and all ok!  [issues with same problem](https://github.com/huggingface/accelerate/issues/1550?ysclid=llvzm7qt8g15639166)